### PR TITLE
fix(funbox): increase layout_mirror difficulty to level 3 (@ShizukoV)

### DIFF
--- a/packages/funbox/src/list.ts
+++ b/packages/funbox/src/list.ts
@@ -133,7 +133,7 @@ const list: Record<FunboxName, FunboxMetadata> = {
   layout_mirror: {
     description: "Mirror the keyboard layout",
     canGetPb: true,
-    difficultyLevel: 1,
+    difficultyLevel: 3,
     properties: ["changesLayout"],
     frontendFunctions: ["applyConfig", "rememberSettings"],
     name: "layout_mirror",


### PR DESCRIPTION
### Description

I've changed the difficulty of the `layout_mirror` funbox from 1 to 3.

The `layout_mirror` funbox completely mirrors the keyboard layout, significantly increasing difficulty compared to other funboxes currently labeled as difficulty level 1, (`earthquake`, `capitals`, `gibberish`), which are much less disruptive.

The `layout_mirror` funbox is also similar to the `mirror` funbox (which mirrors the screen), currently rated at difficulty level 3. Since `layout_mirror` alters the entire keyboard layout itself, making even basic typing extremely challenging, it makes sense for it to also be difficulty level 3.